### PR TITLE
Make admin page redirect if you don't have permission.

### DIFF
--- a/view/admin.php
+++ b/view/admin.php
@@ -5,12 +5,21 @@
  * Date: 2/5/17
  * Time: 7:07 PM
  */
-
+if(!isset($_SESSION['user']['admin']))
+{
+  header('Location: https://ctflearn.com/index.php', true, 302);
+  die();
+}
+if(!$_SESSION['user']['admin'])
+{
+  header('Location: https://ctflearn.com/index.php', true, 302);
+  die();
+}
 ?>
 
 <html>
 <head>
-    <?php include 'head.php'?>
+    <?php include 'head.php' ?>
 </head>
 <body>
 <div class="container section">


### PR DESCRIPTION
Make admin page redirect if you don't have permission.
Please note this code is untested. I do not have PHP development tools currently set up. 
See the following for where I obtained the code to properly redirect: https://stackoverflow.com/questions/768431/how-to-make-a-redirect-in-php#768472

Reason for this PR:
Any user can access the admin.php page. This is unnecessary, and thus this commit fixes that. The usage of die() is to prevent malicious bots. 